### PR TITLE
Allow Rackspace adapter to use the Servicenet to increase performance and remove bandwidth charges.

### DIFF
--- a/src/Adapters/RackspaceConnector.php
+++ b/src/Adapters/RackspaceConnector.php
@@ -64,8 +64,12 @@ class RackspaceConnector implements ConnectorInterface
         if (!array_key_exists('endpoint', $config) || !array_key_exists('container', $config)) {
             throw new \InvalidArgumentException('The rackspace connector requires configuration.');
         }
+        
+        if(!array_key_exists('urltype', $config)) {
+            $config['urltype'] = null;
+        }
 
-        return array_only($config, array('username', 'password', 'endpoint', 'container'));
+        return array_only($config, array('username', 'password', 'endpoint', 'container', 'urltype'));
     }
 
     /**
@@ -82,7 +86,7 @@ class RackspaceConnector implements ConnectorInterface
             'apiKey' => $auth['password'],
         ));
 
-        return $client->objectStoreService('cloudFiles', 'LON')->getContainer($auth['container']);
+        return $client->objectStoreService('cloudFiles', 'LON', $auth['urltype'])->getContainer($auth['container']);
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -108,6 +108,7 @@ return array(
             'username'  => 'your-username',
             'password'  => 'your-password',
             'container' => 'your-container',
+            'urltype'   => 'internalURL', // The URL type ("publicURL" or "internalURL")
             // 'eventable' => true,
             // 'cache'     => 'foo'
         ),


### PR DESCRIPTION
When a server is on the same network and region, the Rackspace internal network may be used to give increased performance and remove bandwidth charges.