### PR TITLE
Issue with config key & service provider setupConfig() & test variable $old being null

### DIFF
--- a/src/FlysystemManager.php
+++ b/src/FlysystemManager.php
@@ -108,7 +108,7 @@ class FlysystemManager extends AbstractManager
     {
         $name = $name ?: $this->getDefaultConnection();
 
-        $connections = $this->config->get($this->getConfigName().'::connections');
+        $connections = $this->config->get($this->getConfigName().'.connections');
 
         if (!is_array($config = array_get($connections, $name)) && !$config) {
             throw new InvalidArgumentException("Adapter [$name] not configured.");
@@ -134,7 +134,7 @@ class FlysystemManager extends AbstractManager
      */
     protected function getCacheConfig($name)
     {
-        $cache = $this->config->get($this->getConfigName().'::cache');
+        $cache = $this->config->get($this->getConfigName().'.cache');
 
         if (!is_array($config = array_get($cache, $name)) && !$config) {
             throw new InvalidArgumentException("Cache [$name] not configured.");

--- a/src/FlysystemServiceProvider.php
+++ b/src/FlysystemServiceProvider.php
@@ -42,7 +42,7 @@ class FlysystemServiceProvider extends ServiceProvider
 
         $this->publishes([$source => config_path('flysystem.php')]);
 
-        $this->mergeConfigFrom('flysystem', $source);
+        $this->mergeConfigFrom($source, 'flysystem');
     }
 
     /**

--- a/tests/Functional/LocalFlysystemTest.php
+++ b/tests/Functional/LocalFlysystemTest.php
@@ -33,7 +33,7 @@ class LocalFlysystemTest extends AbstractTestCase
     {
         $app->files->deleteDirectory(realpath(__DIR__.'/../../').'/temp');
 
-        $old = $app->config->get('flysystem.connections') ? $app->config->get('flysystem.connections') : array();
+        $old = $app->config->get('flysystem.connections') ? $app->config->get('flysystem.connections') : [];
 
         $new = array_merge($old, [
             'testing' => [

--- a/tests/Functional/LocalFlysystemTest.php
+++ b/tests/Functional/LocalFlysystemTest.php
@@ -33,7 +33,7 @@ class LocalFlysystemTest extends AbstractTestCase
     {
         $app->files->deleteDirectory(realpath(__DIR__.'/../../').'/temp');
 
-        $old = $app->config->get('flysystem.connections');
+        $old = $app->config->get('flysystem.connections') ? $app->config->get('flysystem.connections') : array();
 
         $new = array_merge($old, [
             'testing' => [


### PR DESCRIPTION
In FlysystemServiceProvider function setupConfig(), mergeConfigFrom() had its inputs reversed. Source should be first and config name after. 
Also wrong string concat for grabbing config in FlysystemManager function getConnectionConfig(). Should be '.connections' not '::connections'.
Furthermore in LocalFlysystemTest I modified the $old variable to be an empty array if config returns null. 