### PR TITLE
Add config to use publicURL or internalURL in RackspaceConnector

### DIFF
--- a/src/Adapters/RackspaceConnector.php
+++ b/src/Adapters/RackspaceConnector.php
@@ -69,7 +69,7 @@ class RackspaceConnector implements ConnectorInterface
             throw new InvalidArgumentException('The rackspace connector requires a valid urlType.');
         }
 
-        return array_only($config, ['username', 'apiKey', 'endpoint', 'region', 'container']);
+        return array_only($config, ['username', 'apiKey', 'endpoint', 'region', 'container', 'urlType']);
     }
 
     /**

--- a/src/Adapters/RackspaceConnector.php
+++ b/src/Adapters/RackspaceConnector.php
@@ -64,6 +64,11 @@ class RackspaceConnector implements ConnectorInterface
             throw new InvalidArgumentException('The rackspace connector requires a container.');
         }
 
+        $config['urlType'] = array_get($config, 'urlType', array_get($config, 'internal', false) ? 'internalURL' : 'publicURL');
+        if (!in_array($config['urlType'], ['internalURL', 'publicURL'])) {
+            throw new InvalidArgumentException('The rackspace connector requires a valid urlType.');
+        }
+
         return array_only($config, ['username', 'apiKey', 'endpoint', 'region', 'container']);
     }
 
@@ -81,7 +86,7 @@ class RackspaceConnector implements ConnectorInterface
             'apiKey'   => $auth['apiKey'],
         ]);
 
-        return $client->objectStoreService('cloudFiles', $auth['region'])->getContainer($auth['container']);
+        return $client->objectStoreService('cloudFiles', $auth['region'], $auth['urlType'])->getContainer($auth['container']);
     }
 
     /**

--- a/src/Adapters/RackspaceConnector.php
+++ b/src/Adapters/RackspaceConnector.php
@@ -64,12 +64,7 @@ class RackspaceConnector implements ConnectorInterface
             throw new InvalidArgumentException('The rackspace connector requires a container.');
         }
 
-        $config['urlType'] = array_get($config, 'urlType', array_get($config, 'internal', false) ? 'internalURL' : 'publicURL');
-        if (!in_array($config['urlType'], ['internalURL', 'publicURL'])) {
-            throw new InvalidArgumentException('The rackspace connector requires a valid urlType.');
-        }
-
-        return array_only($config, ['username', 'apiKey', 'endpoint', 'region', 'container', 'urlType']);
+        return array_only($config, ['username', 'apiKey', 'endpoint', 'region', 'container', 'internal']);
     }
 
     /**
@@ -86,7 +81,9 @@ class RackspaceConnector implements ConnectorInterface
             'apiKey'   => $auth['apiKey'],
         ]);
 
-        return $client->objectStoreService('cloudFiles', $auth['region'], $auth['urlType'])->getContainer($auth['container']);
+        $urlType = array_get($auth, 'internal', false) ? 'internalURL' : 'publicURL';
+
+        return $client->objectStoreService('cloudFiles', $auth['region'], $urlType)->getContainer($auth['container']);
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -128,6 +128,7 @@ return [
             'username'   => 'your-username',
             'apiKey'     => 'your-api-key',
             'container'  => 'your-container',
+            // 'internal'    => true,
             // 'visibility' => 'public',
             // 'eventable'  => true,
             // 'cache'      => 'foo'

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -128,7 +128,7 @@ return [
             'username'   => 'your-username',
             'apiKey'     => 'your-api-key',
             'container'  => 'your-container',
-            // 'internal'    => true,
+            // 'internal'   => true,
             // 'visibility' => 'public',
             // 'eventable'  => true,
             // 'cache'      => 'foo'

--- a/tests/Adapters/RackspaceConnectorTest.php
+++ b/tests/Adapters/RackspaceConnectorTest.php
@@ -124,7 +124,7 @@ class RackspaceConnectorTest extends AbstractTestCase
             'username'  => 'your-username',
             'apiKey'    => 'your-api-key',
             'container' => 'your-container',
-            'urlType'   => 'invalidURL'
+            'urlType'   => 'invalidURL',
         ]);
     }
 

--- a/tests/Adapters/RackspaceConnectorTest.php
+++ b/tests/Adapters/RackspaceConnectorTest.php
@@ -112,6 +112,22 @@ class RackspaceConnectorTest extends AbstractTestCase
         ]);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConnectWithInvalidUrlType()
+    {
+        $connector = $this->getRackspaceConnector();
+
+        $connector->connect([
+            'region'    => 'LON',
+            'username'  => 'your-username',
+            'apiKey'    => 'your-api-key',
+            'container' => 'your-container',
+            'urlType'   => 'invalidURL'
+        ]);
+    }
+
     protected function getRackspaceConnector()
     {
         return new RackspaceConnector();

--- a/tests/Adapters/RackspaceConnectorTest.php
+++ b/tests/Adapters/RackspaceConnectorTest.php
@@ -113,18 +113,19 @@ class RackspaceConnectorTest extends AbstractTestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException \Guzzle\Http\Exception\ClientErrorResponseException
      */
-    public function testConnectWithInvalidUrlType()
+    public function testConnectWithInternal()
     {
         $connector = $this->getRackspaceConnector();
 
         $connector->connect([
+            'endpoint'  => 'https://lon.identity.api.rackspacecloud.com/v2.0/',
             'region'    => 'LON',
             'username'  => 'your-username',
             'apiKey'    => 'your-api-key',
             'container' => 'your-container',
-            'urlType'   => 'invalidURL',
+            'internal'  => true,
         ]);
     }
 


### PR DESCRIPTION
This commit allows the Rackspace adaptor to use the internal url (sometimes called ServiceNet), which does not charge for bandwidth inside Rackspace servers.

It still defaults to the public url, which means this doesn't change anything unless a config is added. The config can be added as a boolean called "internal" or as a string called "urlType". The reason for having both is to not leak a implementation detail from Rackspace's OpenCloud, which is that urlType must be either internalURL or publicURL, so the internal boolean flag can be used. But we still allow a new urlType to be added in the future.