### PR TITLE
Add config to use publicURL or internalURL in RackspaceConnector

### DIFF
--- a/config/flysystem.php
+++ b/config/flysystem.php
@@ -131,6 +131,7 @@ return [
             'username'   => 'your-username',
             'apiKey'     => 'your-api-key',
             'container'  => 'your-container',
+            // 'internal'    => true,
             // 'visibility' => 'public',
             // 'eventable'  => true,
             // 'cache'      => 'foo'

--- a/config/flysystem.php
+++ b/config/flysystem.php
@@ -131,7 +131,7 @@ return [
             'username'   => 'your-username',
             'apiKey'     => 'your-api-key',
             'container'  => 'your-container',
-            // 'internal'    => true,
+            // 'internal'   => true,
             // 'visibility' => 'public',
             // 'eventable'  => true,
             // 'cache'      => 'foo'

--- a/config/flysystem.php
+++ b/config/flysystem.php
@@ -131,7 +131,7 @@ return [
             'username'   => 'your-username',
             'apiKey'     => 'your-api-key',
             'container'  => 'your-container',
-            // 'internal'   => true,
+            // 'internal'   => false,
             // 'visibility' => 'public',
             // 'eventable'  => true,
             // 'cache'      => 'foo'

--- a/src/Adapters/RackspaceConnector.php
+++ b/src/Adapters/RackspaceConnector.php
@@ -68,6 +68,11 @@ class RackspaceConnector implements ConnectorInterface
             throw new InvalidArgumentException('The rackspace connector requires container configuration.');
         }
 
+        $config['urlType'] = array_get($config, 'urlType', array_get($config, 'internal', false) ? 'internalURL' : 'publicURL');
+        if (!in_array($config['urlType'], ['internalURL', 'publicURL'])) {
+            throw new InvalidArgumentException('The rackspace connector requires a valid urlType.');
+        }
+
         return array_only($config, ['username', 'apiKey', 'endpoint', 'region', 'container']);
     }
 
@@ -85,7 +90,7 @@ class RackspaceConnector implements ConnectorInterface
             'apiKey'   => $auth['apiKey'],
         ]);
 
-        return $client->objectStoreService('cloudFiles', $auth['region'])->getContainer($auth['container']);
+        return $client->objectStoreService('cloudFiles', $auth['region'], $auth['urlType'])->getContainer($auth['container']);
     }
 
     /**

--- a/src/Adapters/RackspaceConnector.php
+++ b/src/Adapters/RackspaceConnector.php
@@ -73,7 +73,7 @@ class RackspaceConnector implements ConnectorInterface
             throw new InvalidArgumentException('The rackspace connector requires a valid urlType.');
         }
 
-        return array_only($config, ['username', 'apiKey', 'endpoint', 'region', 'container']);
+        return array_only($config, ['username', 'apiKey', 'endpoint', 'region', 'container', 'urlType']);
     }
 
     /**

--- a/src/Adapters/RackspaceConnector.php
+++ b/src/Adapters/RackspaceConnector.php
@@ -68,12 +68,7 @@ class RackspaceConnector implements ConnectorInterface
             throw new InvalidArgumentException('The rackspace connector requires container configuration.');
         }
 
-        $config['urlType'] = array_get($config, 'urlType', array_get($config, 'internal', false) ? 'internalURL' : 'publicURL');
-        if (!in_array($config['urlType'], ['internalURL', 'publicURL'])) {
-            throw new InvalidArgumentException('The rackspace connector requires a valid urlType.');
-        }
-
-        return array_only($config, ['username', 'apiKey', 'endpoint', 'region', 'container', 'urlType']);
+        return array_only($config, ['username', 'apiKey', 'endpoint', 'region', 'container', 'internal']);
     }
 
     /**
@@ -90,7 +85,9 @@ class RackspaceConnector implements ConnectorInterface
             'apiKey'   => $auth['apiKey'],
         ]);
 
-        return $client->objectStoreService('cloudFiles', $auth['region'], $auth['urlType'])->getContainer($auth['container']);
+        $urlType = array_get($auth, 'internal', false) ? 'internalURL' : 'publicURL';
+
+        return $client->objectStoreService('cloudFiles', $auth['region'], $urlType)->getContainer($auth['container']);
     }
 
     /**

--- a/tests/Adapters/RackspaceConnectorTest.php
+++ b/tests/Adapters/RackspaceConnectorTest.php
@@ -123,18 +123,19 @@ class RackspaceConnectorTest extends AbstractTestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException \Guzzle\Http\Exception\ClientErrorResponseException
      */
-    public function testConnectWithInvalidUrlType()
+    public function testConnectWithInternal()
     {
         $connector = $this->getRackspaceConnector();
 
         $connector->connect([
+            'endpoint'  => 'https://lon.identity.api.rackspacecloud.com/v2.0/',
             'region'    => 'LON',
             'username'  => 'your-username',
             'apiKey'    => 'your-api-key',
             'container' => 'your-container',
-            'urlType'   => 'invalidURL',
+            'internal'  => true,
         ]);
     }
 

--- a/tests/Adapters/RackspaceConnectorTest.php
+++ b/tests/Adapters/RackspaceConnectorTest.php
@@ -122,6 +122,22 @@ class RackspaceConnectorTest extends AbstractTestCase
         ]);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConnectWithInvalidUrlType()
+    {
+        $connector = $this->getRackspaceConnector();
+
+        $connector->connect([
+            'region'    => 'LON',
+            'username'  => 'your-username',
+            'apiKey'    => 'your-api-key',
+            'container' => 'your-container',
+            'urlType'   => 'invalidURL'
+        ]);
+    }
+
     protected function getRackspaceConnector()
     {
         return new RackspaceConnector();

--- a/tests/Adapters/RackspaceConnectorTest.php
+++ b/tests/Adapters/RackspaceConnectorTest.php
@@ -129,14 +129,40 @@ class RackspaceConnectorTest extends AbstractTestCase
     {
         $connector = $this->getRackspaceConnector();
 
-        $connector->connect([
-            'endpoint'  => 'https://lon.identity.api.rackspacecloud.com/v2.0/',
-            'region'    => 'LON',
-            'username'  => 'your-username',
-            'apiKey'    => 'your-api-key',
-            'container' => 'your-container',
-            'internal'  => true,
-        ]);
+        try {
+            $connector->connect([
+                'endpoint'  => 'https://lon.identity.api.rackspacecloud.com/v2.0/',
+                'region'    => 'LON',
+                'username'  => 'your-username',
+                'apiKey'    => 'your-api-key',
+                'container' => 'your-container',
+                'internal'  => true,
+            ]);
+        } catch (CurlException $e) {
+            $this->markTestSkipped('No internet connection');
+        }
+    }
+
+
+    /**
+     * @expectedException \Guzzle\Http\Exception\ClientErrorResponseException
+     */
+    public function testConnectWithInternalFalse()
+    {
+        $connector = $this->getRackspaceConnector();
+
+        try {
+            $connector->connect([
+                'endpoint'  => 'https://lon.identity.api.rackspacecloud.com/v2.0/',
+                'region'    => 'LON',
+                'username'  => 'your-username',
+                'apiKey'    => 'your-api-key',
+                'container' => 'your-container',
+                'internal'  => false,
+            ]);
+        } catch (CurlException $e) {
+            $this->markTestSkipped('No internet connection');
+        }
     }
 
     protected function getRackspaceConnector()

--- a/tests/Adapters/RackspaceConnectorTest.php
+++ b/tests/Adapters/RackspaceConnectorTest.php
@@ -134,7 +134,7 @@ class RackspaceConnectorTest extends AbstractTestCase
             'username'  => 'your-username',
             'apiKey'    => 'your-api-key',
             'container' => 'your-container',
-            'urlType'   => 'invalidURL'
+            'urlType'   => 'invalidURL',
         ]);
     }
 

--- a/tests/Adapters/RackspaceConnectorTest.php
+++ b/tests/Adapters/RackspaceConnectorTest.php
@@ -143,7 +143,6 @@ class RackspaceConnectorTest extends AbstractTestCase
         }
     }
 
-
     /**
      * @expectedException \Guzzle\Http\Exception\ClientErrorResponseException
      */


### PR DESCRIPTION
This commit allows the Rackspace adaptor to use the internal url (sometimes called ServiceNet), which does not charge for bandwidth inside Rackspace servers.

Based on #57 for latest version.