### PR TITLE
Update adapters for Laravel4 branch to updated version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To get the latest version of Laravel Flysystem, simply add the following line to
 
 There are some additional dependencies you will need to install for some of the features:
 
-* The AwsS3 adapter requires `"league/flysystem-aws-s3-v2": "~1.0"` in your `composer.json`.
+* The AwsS3 adapter requires `"league/flysystem-aws-s3-v3": "~1.0"` in your `composer.json`.
 * The Azure adapter requires `"league/flysystem-azure": "~1.0"` in your `composer.json`.
 * The Copy adapter requires `"league/flysystem-copy": "~1.0"` in your `composer.json`.
 * The Dropbox adapter requires `"league/flysystem-dropbox": "~1.0"` in your `composer.json`.

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "authors": [
         {
             "name": "Graham Campbell",
-            "email": "graham@mineuk.com"
+            "email": "graham@cachethq.io"
         }
     ],
     "repositories": [
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "graham-campbell/testbench": "~1.0",
-        "league/flysystem-aws-s3-v2": "~1.0",
+        "league/flysystem-aws-s3-v3": "~1.0",
         "league/flysystem-azure": "~1.0",
         "league/flysystem-cached-adapter": "~1.0",
         "league/flysystem-copy": "~1.0",
@@ -34,10 +34,12 @@
         "league/flysystem-rackspace": "~1.0",
         "league/flysystem-sftp": "~1.0",
         "league/flysystem-webdav": "~1.0",
-        "league/flysystem-ziparchive": "~1.0"
+        "league/flysystem-ziparchive": "~1.0",
+        "mockery/mockery": "^0.9.4",
+        "phpunit/phpunit": "^4.7.6"
     },
     "suggest": {
-        "league/flysystem-aws-s3-v2": "AwsS3 adapter support.",
+        "league/flysystem-aws-s3-v3": "AwsS3 adapter support.",
         "league/flysystem-azure": "Azure adapter support.",
         "league/flysystem-cached-adapter": "Adapter caching support.",
         "league/flysystem-copy": "Copy adapter support.",

--- a/src/Adapters/AwsS3Connector.php
+++ b/src/Adapters/AwsS3Connector.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -14,12 +14,13 @@ namespace GrahamCampbell\Flysystem\Adapters;
 use Aws\S3\S3Client;
 use GrahamCampbell\Manager\ConnectorInterface;
 use InvalidArgumentException;
-use League\Flysystem\AwsS3v2\AwsS3Adapter;
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
 
 /**
  * This is the awss3 connector class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
+ * @author Raul Ruiz <publiux@gmail.com>
  */
 class AwsS3Connector implements ConnectorInterface
 {
@@ -28,7 +29,7 @@ class AwsS3Connector implements ConnectorInterface
      *
      * @param string[] $config
      *
-     * @return \League\Flysystem\AwsS3v2\AwsS3Adapter
+     * @return \League\Flysystem\AwsS3v3\AwsS3Adapter
      */
     public function connect(array $config)
     {
@@ -54,19 +55,37 @@ class AwsS3Connector implements ConnectorInterface
             throw new InvalidArgumentException('The awss3 connector requires authentication.');
         }
 
-        if (array_key_exists('region', $config) && array_key_exists('base_url', $config)) {
-            return array_only($config, ['key', 'secret', 'region', 'base_url']);
+        if (!array_key_exists('version', $config)) {
+            throw new InvalidArgumentException('The awss3 connector requires that you specify the api version.');
         }
 
-        if (array_key_exists('region', $config)) {
-            return array_only($config, ['key', 'secret', 'region']);
+        if (!array_key_exists('region', $config)) {
+            throw new InvalidArgumentException('The awss3 connector requires that you specify the region.');
         }
 
-        if (array_key_exists('base_url', $config)) {
-            return array_only($config, ['key', 'secret', 'base_url']);
+        $auth = [
+            'region'      => $config['region'],
+            'version'     => $config['version'],
+            'credentials' => array_only($config, ['key', 'secret']),
+        ];
+
+        if (array_key_exists('bucket_endpoint', $config)) {
+            $auth['bucket_endpoint'] = $config['bucket_endpoint'];
         }
 
-        return array_only($config, ['key', 'secret']);
+        if (array_key_exists('calculate_md5', $config)) {
+            $auth['calculate_md5'] = $config['calculate_md5'];
+        }
+
+        if (array_key_exists('scheme', $config)) {
+            $auth['scheme'] = $config['scheme'];
+        }
+
+        if (array_key_exists('endpoint', $config)) {
+            $auth['endpoint'] = $config['endpoint'];
+        }
+
+        return $auth;
     }
 
     /**
@@ -78,7 +97,7 @@ class AwsS3Connector implements ConnectorInterface
      */
     protected function getClient(array $auth)
     {
-        return S3Client::factory($auth);
+        return new S3Client($auth);
     }
 
     /**
@@ -100,11 +119,7 @@ class AwsS3Connector implements ConnectorInterface
             throw new InvalidArgumentException('The awss3 connector requires a bucket.');
         }
 
-        if (!array_key_exists('options', $config)) {
-            $config['options'] = [];
-        }
-
-        return array_only($config, ['bucket', 'prefix', 'options']);
+        return array_only($config, ['bucket', 'prefix']);
     }
 
     /**
@@ -113,10 +128,10 @@ class AwsS3Connector implements ConnectorInterface
      * @param \Aws\S3\S3Client $client
      * @param string[]         $config
      *
-     * @return \League\Flysystem\AwsS3v2\AwsS3Adapter
+     * @return \League\Flysystem\AwsS3v3\AwsS3Adapter
      */
     protected function getAdapter(S3Client $client, array $config)
     {
-        return new AwsS3Adapter($client, $config['bucket'], $config['prefix'], $config['options']);
+        return new AwsS3Adapter($client, $config['bucket'], $config['prefix']);
     }
 }

--- a/src/Adapters/AzureConnector.php
+++ b/src/Adapters/AzureConnector.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,14 +13,14 @@ namespace GrahamCampbell\Flysystem\Adapters;
 
 use GrahamCampbell\Manager\ConnectorInterface;
 use InvalidArgumentException;
-use League\Flysystem\Azure\Adapter;
+use League\Flysystem\Azure\AzureAdapter;
 use WindowsAzure\Blob\Internal\IBlob;
 use WindowsAzure\Common\ServicesBuilder;
 
 /**
  * This is the azure connector class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class AzureConnector implements ConnectorInterface
 {
@@ -29,7 +29,7 @@ class AzureConnector implements ConnectorInterface
      *
      * @param string[] $config
      *
-     * @return \League\Flysystem\Azure\Adapter
+     * @return \League\Flysystem\Azure\AzureAdapter
      */
     public function connect(array $config)
     {
@@ -67,7 +67,7 @@ class AzureConnector implements ConnectorInterface
      */
     protected function getClient(array $auth)
     {
-        $endpoint = sprintf('DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s', base64_encode($auth['account-name']), base64_encode($auth['api-key']));
+        $endpoint = sprintf('DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s', $auth['account-name'], $auth['api-key']);
 
         return ServicesBuilder::getInstance()->createBlobService($endpoint);
     }
@@ -94,10 +94,10 @@ class AzureConnector implements ConnectorInterface
      * @param \WindowsAzure\Blob\Internal\IBlob $client
      * @param string[]                          $config
      *
-     * @return \League\Flysystem\Azure\Adapter
+     * @return \League\Flysystem\Azure\AzureAdapter
      */
     protected function getAdapter(IBlob $client, array $config)
     {
-        return new Adapter($client, $config['container']);
+        return new AzureAdapter($client, $config['container']);
     }
 }

--- a/src/Adapters/ConnectionFactory.php
+++ b/src/Adapters/ConnectionFactory.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -16,7 +16,7 @@ use InvalidArgumentException;
 /**
  * This is the adapter connection factory class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class ConnectionFactory
 {

--- a/src/Adapters/CopyConnector.php
+++ b/src/Adapters/CopyConnector.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -19,7 +19,7 @@ use League\Flysystem\Copy\CopyAdapter;
 /**
  * This is the copy connector class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class CopyConnector implements ConnectorInterface
 {

--- a/src/Adapters/DropboxConnector.php
+++ b/src/Adapters/DropboxConnector.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -19,7 +19,7 @@ use League\Flysystem\Dropbox\DropboxAdapter;
 /**
  * This is the dropbox connector class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class DropboxConnector implements ConnectorInterface
 {

--- a/src/Adapters/FtpConnector.php
+++ b/src/Adapters/FtpConnector.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -17,7 +17,7 @@ use League\Flysystem\Adapter\Ftp;
 /**
  * This is the ftp connector class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class FtpConnector implements ConnectorInterface
 {

--- a/src/Adapters/GridFSConnector.php
+++ b/src/Adapters/GridFSConnector.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -19,7 +19,7 @@ use MongoClient;
 /**
  * This is the gridfs connector class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class GridFSConnector implements ConnectorInterface
 {

--- a/src/Adapters/LocalConnector.php
+++ b/src/Adapters/LocalConnector.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -18,7 +18,7 @@ use League\Flysystem\Adapter\Local;
 /**
  * This is the local connector class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class LocalConnector implements ConnectorInterface
 {

--- a/src/Adapters/NullConnector.php
+++ b/src/Adapters/NullConnector.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -17,7 +17,7 @@ use League\Flysystem\Adapter\NullAdapter;
 /**
  * This is the null connector class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class NullConnector implements ConnectorInterface
 {

--- a/src/Adapters/RackspaceConnector.php
+++ b/src/Adapters/RackspaceConnector.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -20,7 +20,7 @@ use OpenCloud\Rackspace as OpenStackRackspace;
 /**
  * This is the rackspace connector class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class RackspaceConnector implements ConnectorInterface
 {

--- a/src/Adapters/SftpConnector.php
+++ b/src/Adapters/SftpConnector.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -17,7 +17,7 @@ use League\Flysystem\Sftp\SftpAdapter;
 /**
  * This is the sftp connector class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class SftpConnector implements ConnectorInterface
 {

--- a/src/Adapters/WebDavConnector.php
+++ b/src/Adapters/WebDavConnector.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -18,7 +18,7 @@ use Sabre\DAV\Client;
 /**
  * This is the webdav connector class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class WebDavConnector implements ConnectorInterface
 {

--- a/src/Adapters/ZipConnector.php
+++ b/src/Adapters/ZipConnector.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -18,7 +18,7 @@ use League\Flysystem\ZipArchive\ZipArchiveAdapter;
 /**
  * This is the zip connector class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class ZipConnector implements ConnectorInterface
 {

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -38,17 +38,20 @@ return [
     'connections' => [
 
         'awss3' => [
-            'driver'     => 'awss3',
-            'key'        => 'your-key',
-            'secret'     => 'your-secret',
-            'bucket'     => 'your-bucket',
-            // 'region'     => 'your-region',
-            // 'base_url'   => 'your-url',
-            // 'options'    => array(),
-            // 'prefix'     => 'your-prefix',
-            // 'visibility' => 'public',
-            // 'eventable'  => true,
-            // 'cache'      => 'foo'
+            'driver'          => 'awss3',
+            'key'             => 'your-key',
+            'secret'          => 'your-secret',
+            'bucket'          => 'your-bucket',
+            'region'          => 'your-region',
+            'version'         => 'latest',
+            // 'bucket_endpoint' => false,
+            // 'calculate_md5'   => true,
+            // 'scheme'          => 'https',
+            // 'endpoint'        => 'your-url',
+            // 'prefix'          => 'your-prefix',
+            // 'visibility'      => 'public',
+            // 'eventable'       => true,
+            // 'cache'           => 'foo'
         ],
 
         'azure' => [
@@ -199,7 +202,7 @@ return [
 
         'bar' => [
             'driver'    => 'illuminate',
-            'connector' => 'redis', // app/config/cache.php
+            'connector' => 'redis', // config/cache.php
             'key'       => 'bar',
             'ttl'       => 600,
         ],

--- a/tests/Adapters/AwsS3ConnectorTest.php
+++ b/tests/Adapters/AwsS3ConnectorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,11 +13,13 @@ namespace GrahamCampbell\Tests\Flysystem\Adapters;
 
 use GrahamCampbell\Flysystem\Adapters\AwsS3Connector;
 use GrahamCampbell\TestBench\AbstractTestCase;
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
 
 /**
  * This is the awss3 connector test class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
+ * @author Raul Ruiz <publiux@gmail.com>
  */
 class AwsS3ConnectorTest extends AbstractTestCase
 {
@@ -26,12 +28,14 @@ class AwsS3ConnectorTest extends AbstractTestCase
         $connector = $this->getAwsS3Connector();
 
         $return = $connector->connect([
-            'key'    => 'your-key',
-            'secret' => 'your-secret',
-            'bucket' => 'your-bucket',
+            'key'     => 'your-key',
+            'secret'  => 'your-secret',
+            'bucket'  => 'your-bucket',
+            'region'  => 'us-east-1',
+            'version' => 'latest',
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\AwsS3v2\AwsS3Adapter', $return);
+        $this->assertInstanceOf(AwsS3Adapter::class, $return);
     }
 
     public function testConnectWithPrefix()
@@ -39,30 +43,66 @@ class AwsS3ConnectorTest extends AbstractTestCase
         $connector = $this->getAwsS3Connector();
 
         $return = $connector->connect([
-            'key'    => 'your-key',
-            'secret' => 'your-secret',
-            'bucket' => 'your-bucket',
-            'prefix' => 'your-prefix',
+            'key'     => 'your-key',
+            'secret'  => 'your-secret',
+            'bucket'  => 'your-bucket',
+            'region'  => 'us-east-1',
+            'version' => 'latest',
+            'prefix'  => 'your-prefix',
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\AwsS3v2\AwsS3Adapter', $return);
+        $this->assertInstanceOf(AwsS3Adapter::class, $return);
     }
 
-    public function testConnectWithRegion()
+    public function testConnectWithBucketEndPoint()
     {
         $connector = $this->getAwsS3Connector();
 
         $return = $connector->connect([
-            'key'    => 'your-key',
-            'secret' => 'your-secret',
-            'bucket' => 'your-bucket',
-            'region' => 'eu-west-1',
+            'key'             => 'your-key',
+            'secret'          => 'your-secret',
+            'bucket'          => 'your-bucket',
+            'region'          => 'us-east-1',
+            'version'         => 'latest',
+            'bucket_endpoint' => false,
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\AwsS3v2\AwsS3Adapter', $return);
+        $this->assertInstanceOf(AwsS3Adapter::class, $return);
     }
 
-    public function testConnectWithBaseUrl()
+    public function testConnectWithCalculateMD5()
+    {
+        $connector = $this->getAwsS3Connector();
+
+        $return = $connector->connect([
+            'key'           => 'your-key',
+            'secret'        => 'your-secret',
+            'bucket'        => 'your-bucket',
+            'region'        => 'us-east-1',
+            'version'       => 'latest',
+            'calculate_md5' => true,
+        ]);
+
+        $this->assertInstanceOf(AwsS3Adapter::class, $return);
+    }
+
+    public function testConnectWithScheme()
+    {
+        $connector = $this->getAwsS3Connector();
+
+        $return = $connector->connect([
+            'key'     => 'your-key',
+            'secret'  => 'your-secret',
+            'bucket'  => 'your-bucket',
+            'region'  => 'us-east-1',
+            'version' => 'latest',
+            'scheme'  => 'https',
+        ]);
+
+        $this->assertInstanceOf(AwsS3Adapter::class, $return);
+    }
+
+    public function testConnectWithEndPoint()
     {
         $connector = $this->getAwsS3Connector();
 
@@ -70,24 +110,12 @@ class AwsS3ConnectorTest extends AbstractTestCase
             'key'      => 'your-key',
             'secret'   => 'your-secret',
             'bucket'   => 'your-bucket',
-            'base_url' => 'your-url',
+            'region'   => 'us-east-1',
+            'version'  => 'latest',
+            'endpoint' => 'your-url',
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\AwsS3v2\AwsS3Adapter', $return);
-    }
-
-    public function testConnectWithOptions()
-    {
-        $connector = $this->getAwsS3Connector();
-
-        $return = $connector->connect([
-            'key'      => 'your-key',
-            'secret'   => 'your-secret',
-            'bucket'   => 'your-bucket',
-            'options'  => ['foo' => 'bar'],
-        ]);
-
-        $this->assertInstanceOf('League\Flysystem\AwsS3v2\AwsS3Adapter', $return);
+        $this->assertInstanceOf(AwsS3Adapter::class, $return);
     }
 
     public function testConnectWithEverything()
@@ -95,15 +123,18 @@ class AwsS3ConnectorTest extends AbstractTestCase
         $connector = $this->getAwsS3Connector();
 
         $return = $connector->connect([
-            'key'      => 'your-key',
-            'secret'   => 'your-secret',
-            'bucket'   => 'your-bucket',
-            'region'   => 'eu-west-1',
-            'base_url' => 'your-url',
-            'options'  => ['foo' => 'bar'],
+            'key'             => 'your-key',
+            'secret'          => 'your-secret',
+            'bucket'          => 'your-bucket',
+            'region'          => 'your-region',
+            'version'         => 'latest',
+            'bucket_endpoint' => false,
+            'calculate_md5'   => true,
+            'scheme'          => 'https',
+            'endpoint'        => 'your-url',
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\AwsS3v2\AwsS3Adapter', $return);
+        $this->assertInstanceOf(AwsS3Adapter::class, $return);
     }
 
     /**
@@ -113,7 +144,12 @@ class AwsS3ConnectorTest extends AbstractTestCase
     {
         $connector = $this->getAwsS3Connector();
 
-        $connector->connect(['key' => 'your-key', 'secret' => 'your-secret']);
+        $connector->connect([
+            'key'     => 'your-key',
+            'secret'  => 'your-secret',
+            'region'  => 'us-east-1',
+            'version' => 'latest',
+        ]);
     }
 
     /**
@@ -123,7 +159,12 @@ class AwsS3ConnectorTest extends AbstractTestCase
     {
         $connector = $this->getAwsS3Connector();
 
-        $connector->connect(['secret' => 'your-secret', 'bucket' => 'your-bucket']);
+        $connector->connect([
+            'secret'  => 'your-secret',
+            'bucket'  => 'your-bucket',
+            'region'  => 'us-east-1',
+            'version' => 'latest',
+        ]);
     }
 
     /**
@@ -133,7 +174,42 @@ class AwsS3ConnectorTest extends AbstractTestCase
     {
         $connector = $this->getAwsS3Connector();
 
-        $connector->connect(['key' => 'your-key', 'bucket' => 'your-bucket']);
+        $connector->connect([
+            'key'     => 'your-key',
+            'bucket'  => 'your-bucket',
+            'region'  => 'us-east-1',
+            'version' => 'latest',
+        ]);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConnectWithoutRegion()
+    {
+        $connector = $this->getAwsS3Connector();
+
+        $connector->connect([
+            'key'     => 'your-key',
+            'secret'  => 'your-secret',
+            'bucket'  => 'your-bucket',
+            'version' => 'latest',
+        ]);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConnectWithoutVersion()
+    {
+        $connector = $this->getAwsS3Connector();
+
+        $connector->connect([
+            'key'    => 'your-key',
+            'secret' => 'your-secret',
+            'bucket' => 'your-bucket',
+            'region' => 'us-east-1',
+        ]);
     }
 
     protected function getAwsS3Connector()

--- a/tests/Adapters/AzureConnectorTest.php
+++ b/tests/Adapters/AzureConnectorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,11 +13,12 @@ namespace GrahamCampbell\Tests\Flysystem\Adapters;
 
 use GrahamCampbell\Flysystem\Adapters\AzureConnector;
 use GrahamCampbell\TestBench\AbstractTestCase;
+use League\Flysystem\Azure\AzureAdapter;
 
 /**
  * This is the adapter connector test class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class AzureConnectorTest extends AbstractTestCase
 {
@@ -27,11 +28,11 @@ class AzureConnectorTest extends AbstractTestCase
 
         $return = $connector->connect([
             'account-name' => 'your-account-name',
-            'api-key'      => 'your-api-key',
+            'api-key'      => 'eW91ci1hcGkta2V5',
             'container'    => 'your-container',
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\Azure\Adapter', $return);
+        $this->assertInstanceOf(AzureAdapter::class, $return);
     }
 
     /**
@@ -42,7 +43,7 @@ class AzureConnectorTest extends AbstractTestCase
         $connector = $this->getAzureConnector();
 
         $connector->connect([
-            'api-key'   => 'your-api-key',
+            'api-key'   => 'eW91ci1hcGkta2V5',
             'container' => 'your-container',
         ]);
     }
@@ -69,7 +70,7 @@ class AzureConnectorTest extends AbstractTestCase
 
         $connector->connect([
             'account-name' => 'your-account-name',
-            'api-key'      => 'your-api-key',
+            'api-key'      => 'eW91ci1hcGkta2V5',
         ]);
     }
 

--- a/tests/Adapters/ConnectionFactoryTest.php
+++ b/tests/Adapters/ConnectionFactoryTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -11,14 +11,28 @@
 
 namespace GrahamCampbell\Tests\Flysystem\Adapters;
 
+use GrahamCampbell\Flysystem\Adapters\AwsS3Connector;
+use GrahamCampbell\Flysystem\Adapters\AzureConnector;
 use GrahamCampbell\Flysystem\Adapters\ConnectionFactory;
+use GrahamCampbell\Flysystem\Adapters\CopyConnector;
+use GrahamCampbell\Flysystem\Adapters\DropboxConnector;
+use GrahamCampbell\Flysystem\Adapters\FtpConnector;
+use GrahamCampbell\Flysystem\Adapters\GridFSConnector;
+use GrahamCampbell\Flysystem\Adapters\LocalConnector;
+use GrahamCampbell\Flysystem\Adapters\NullConnector;
+use GrahamCampbell\Flysystem\Adapters\RackspaceConnector;
+use GrahamCampbell\Flysystem\Adapters\SftpConnector;
+use GrahamCampbell\Flysystem\Adapters\WebDavConnector;
+use GrahamCampbell\Flysystem\Adapters\ZipConnector;
 use GrahamCampbell\TestBench\AbstractTestCase;
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\AdapterInterface;
 use Mockery;
 
 /**
  * This is the adapter connection factory test class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class ConnectionFactoryTest extends AbstractTestCase
 {
@@ -28,24 +42,24 @@ class ConnectionFactoryTest extends AbstractTestCase
 
         $return = $factory->make(['driver' => 'local', 'path' => __DIR__, 'name' => 'local']);
 
-        $this->assertInstanceOf('League\Flysystem\AdapterInterface', $return);
+        $this->assertInstanceOf(AdapterInterface::class, $return);
     }
 
     public function createDataProvider()
     {
         return [
-            ['awss3', 'AwsS3Connector'],
-            ['azure', 'AzureConnector'],
-            ['copy', 'CopyConnector'],
-            ['dropbox', 'DropboxConnector'],
-            ['ftp', 'FtpConnector'],
-            ['gridfs', 'GridFSConnector'],
-            ['local', 'LocalConnector'],
-            ['null', 'NullConnector'],
-            ['rackspace', 'RackspaceConnector'],
-            ['sftp', 'SftpConnector'],
-            ['webdav', 'WebDavConnector'],
-            ['zip', 'ZipConnector'],
+            ['awss3', AwsS3Connector::class],
+            ['azure', AzureConnector::class],
+            ['copy', CopyConnector::class],
+            ['dropbox', DropboxConnector::class],
+            ['ftp', FtpConnector::class],
+            ['gridfs', GridFSConnector::class],
+            ['local', LocalConnector::class],
+            ['null', NullConnector::class],
+            ['rackspace', RackspaceConnector::class],
+            ['sftp', SftpConnector::class],
+            ['webdav', WebDavConnector::class],
+            ['zip', ZipConnector::class],
         ];
     }
 
@@ -58,7 +72,7 @@ class ConnectionFactoryTest extends AbstractTestCase
 
         $return = $factory->createConnector(['driver' => $driver]);
 
-        $this->assertInstanceOf('GrahamCampbell\Flysystem\Adapters\\'.$class, $return);
+        $this->assertInstanceOf($class, $return);
     }
 
     /**
@@ -88,13 +102,13 @@ class ConnectionFactoryTest extends AbstractTestCase
 
     protected function getMockedFactory()
     {
-        $mock = Mockery::mock('GrahamCampbell\Flysystem\Adapters\ConnectionFactory[createConnector]');
+        $mock = Mockery::mock(ConnectionFactory::class.'[createConnector]');
 
-        $connector = Mockery::mock('GrahamCampbell\Flysystem\Adapters\LocalConnector');
+        $connector = Mockery::mock(LocalConnector::class);
 
         $connector->shouldReceive('connect')->once()
             ->with(['name' => 'local', 'driver' => 'local', 'path' => __DIR__])
-            ->andReturn(Mockery::mock('League\Flysystem\Adapter\Local'));
+            ->andReturn(Mockery::mock(Local::class));
 
         $mock->shouldReceive('createConnector')->once()
             ->with(['name' => 'local', 'driver' => 'local', 'path' => __DIR__])

--- a/tests/Adapters/CopyConnectorTest.php
+++ b/tests/Adapters/CopyConnectorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,11 +13,12 @@ namespace GrahamCampbell\Tests\Flysystem\Adapters;
 
 use GrahamCampbell\Flysystem\Adapters\CopyConnector;
 use GrahamCampbell\TestBench\AbstractTestCase;
+use League\Flysystem\Copy\CopyAdapter;
 
 /**
  * This is the copy connector test class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class CopyConnectorTest extends AbstractTestCase
 {
@@ -32,7 +33,7 @@ class CopyConnectorTest extends AbstractTestCase
             'token-secret'    => 'your-token-secret',
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\Copy\CopyAdapter', $return);
+        $this->assertInstanceOf(CopyAdapter::class, $return);
     }
 
     public function testConnectWithPrefix()
@@ -47,7 +48,7 @@ class CopyConnectorTest extends AbstractTestCase
             'prefix'          => 'your-prefix',
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\Copy\CopyAdapter', $return);
+        $this->assertInstanceOf(CopyAdapter::class, $return);
     }
 
     /**

--- a/tests/Adapters/DropboxConnectorTest.php
+++ b/tests/Adapters/DropboxConnectorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,11 +13,12 @@ namespace GrahamCampbell\Tests\Flysystem\Adapters;
 
 use GrahamCampbell\Flysystem\Adapters\DropboxConnector;
 use GrahamCampbell\TestBench\AbstractTestCase;
+use League\Flysystem\Dropbox\DropboxAdapter;
 
 /**
  * This is the dropbox connector test class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class DropboxConnectorTest extends AbstractTestCase
 {
@@ -30,7 +31,7 @@ class DropboxConnectorTest extends AbstractTestCase
             'app'    => 'your-app',
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\Dropbox\DropboxAdapter', $return);
+        $this->assertInstanceOf(DropboxAdapter::class, $return);
     }
 
     public function testConnectWithPrefix()
@@ -43,7 +44,7 @@ class DropboxConnectorTest extends AbstractTestCase
             'prefix' => 'your-prefix',
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\Dropbox\DropboxAdapter', $return);
+        $this->assertInstanceOf(DropboxAdapter::class, $return);
     }
 
     /**

--- a/tests/Adapters/FtpConnectorTest.php
+++ b/tests/Adapters/FtpConnectorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,11 +13,12 @@ namespace GrahamCampbell\Tests\Flysystem\Adapters;
 
 use GrahamCampbell\Flysystem\Adapters\FtpConnector;
 use GrahamCampbell\TestBench\AbstractTestCase;
+use League\Flysystem\Adapter\Ftp;
 
 /**
  * This is the ftp connector test class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class FtpConnectorTest extends AbstractTestCase
 {
@@ -36,7 +37,7 @@ class FtpConnectorTest extends AbstractTestCase
             'password' => 'your-password',
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\Adapter\Ftp', $return);
+        $this->assertInstanceOf(Ftp::class, $return);
     }
 
     protected function getFtpConnector()

--- a/tests/Adapters/GridFSConnectorTest.php
+++ b/tests/Adapters/GridFSConnectorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,56 +13,56 @@ namespace GrahamCampbell\Tests\Flysystem\Adapters;
 
 use GrahamCampbell\Flysystem\Adapters\GridFSConnector;
 use GrahamCampbell\TestBench\AbstractTestCase;
+use League\Flysystem\GridFS\GridFSAdapter;
+use MongoClient;
+use MongoConnectionException;
 
 /**
  * This is the gridfs connector test class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class GridFSConnectorTest extends AbstractTestCase
 {
     public function testConnectStandard()
     {
-        if (!class_exists('MongoClient')) {
+        if (!class_exists(MongoClient::class)) {
             $this->markTestSkipped('The MongoClient class does not exist');
         }
 
         $connector = $this->getGridFSConnector();
 
-        $return = $connector->connect([
-            'server'   => 'mongodb://localhost:27017',
-            'database' => 'your-database',
-        ]);
+        try {
+            $return = $connector->connect([
+                'server'   => 'mongodb://localhost:27017',
+                'database' => 'your-database',
+            ]);
 
-        $this->assertInstanceOf('League\Flysystem\GridFS\GridFSAdapter', $return);
+            $this->assertInstanceOf(GridFSAdapter::class, $return);
+        } catch (MongoConnectionException $e) {
+            $this->markTestSkipped('No mongo serer running');
+        }
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testConnectServer()
-    {
-        $connector = $this->getGridFSConnector();
-
-        $connector->connect([
-            'database' => 'your-database',
-        ]);
-    }
-
-    /**
+     * @depends testConnectStandard
      * @expectedException \InvalidArgumentException
      */
     public function testConnectWithoutDatabase()
     {
-        if (!class_exists('MongoClient')) {
-            $this->markTestSkipped('The MongoClient class does not exist');
-        }
-
         $connector = $this->getGridFSConnector();
 
-        $connector->connect([
-            'server' => 'mongodb://localhost:27017',
-        ]);
+        $connector->connect(['server' => 'mongodb://localhost:27017']);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConnectWithoutServer()
+    {
+        $connector = $this->getGridFSConnector();
+
+        $connector->connect(['database' => 'your-database']);
     }
 
     protected function getGridFSConnector()

--- a/tests/Adapters/LocalConnectorTest.php
+++ b/tests/Adapters/LocalConnectorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,11 +13,12 @@ namespace GrahamCampbell\Tests\Flysystem\Adapters;
 
 use GrahamCampbell\Flysystem\Adapters\LocalConnector;
 use GrahamCampbell\TestBench\AbstractTestCase;
+use League\Flysystem\Adapter\Local;
 
 /**
  * This is the local connector test class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class LocalConnectorTest extends AbstractTestCase
 {
@@ -27,7 +28,7 @@ class LocalConnectorTest extends AbstractTestCase
 
         $return = $connector->connect(['path' => __DIR__]);
 
-        $this->assertInstanceOf('League\Flysystem\Adapter\Local', $return);
+        $this->assertInstanceOf(Local::class, $return);
     }
 
     public function testConnectWithPrefix()
@@ -36,7 +37,7 @@ class LocalConnectorTest extends AbstractTestCase
 
         $return = $connector->connect(['path' => __DIR__, 'prefix' => 'your-prefix']);
 
-        $this->assertInstanceOf('League\Flysystem\Adapter\Local', $return);
+        $this->assertInstanceOf(Local::class, $return);
     }
 
     /**

--- a/tests/Adapters/NullConnectorTest.php
+++ b/tests/Adapters/NullConnectorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,11 +13,12 @@ namespace GrahamCampbell\Tests\Flysystem\Adapters;
 
 use GrahamCampbell\Flysystem\Adapters\NullConnector;
 use GrahamCampbell\TestBench\AbstractTestCase;
+use League\Flysystem\Adapter\NullAdapter;
 
 /**
  * This is the null connector test class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class NullConnectorTest extends AbstractTestCase
 {
@@ -27,7 +28,7 @@ class NullConnectorTest extends AbstractTestCase
 
         $return = $connector->connect([]);
 
-        $this->assertInstanceOf('League\Flysystem\Adapter\NullAdapter', $return);
+        $this->assertInstanceOf(NullAdapter::class, $return);
     }
 
     protected function getNullConnector()

--- a/tests/Adapters/RackspaceConnectorTest.php
+++ b/tests/Adapters/RackspaceConnectorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,11 +13,12 @@ namespace GrahamCampbell\Tests\Flysystem\Adapters;
 
 use GrahamCampbell\Flysystem\Adapters\RackspaceConnector;
 use GrahamCampbell\TestBench\AbstractTestCase;
+use Guzzle\Http\Exception\CurlException;
 
 /**
  * This is the rackspace connector test class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class RackspaceConnectorTest extends AbstractTestCase
 {
@@ -28,13 +29,17 @@ class RackspaceConnectorTest extends AbstractTestCase
     {
         $connector = $this->getRackspaceConnector();
 
-        $connector->connect([
-            'endpoint'  => 'https://lon.identity.api.rackspacecloud.com/v2.0/',
-            'region'    => 'LON',
-            'username'  => 'your-username',
-            'apiKey'    => 'your-api-key',
-            'container' => 'your-container',
-        ]);
+        try {
+            $connector->connect([
+                'endpoint'  => 'https://lon.identity.api.rackspacecloud.com/v2.0/',
+                'region'    => 'LON',
+                'username'  => 'your-username',
+                'apiKey'    => 'your-api-key',
+                'container' => 'your-container',
+            ]);
+        } catch (CurlException $e) {
+            $this->markTestSkipped('No internet connection');
+        }
     }
 
     /**

--- a/tests/Adapters/SftpConnectorTest.php
+++ b/tests/Adapters/SftpConnectorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,11 +13,12 @@ namespace GrahamCampbell\Tests\Flysystem\Adapters;
 
 use GrahamCampbell\Flysystem\Adapters\SftpConnector;
 use GrahamCampbell\TestBench\AbstractTestCase;
+use League\Flysystem\Sftp\SftpAdapter;
 
 /**
  * This is the sftp connector test class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class SftpConnectorTest extends AbstractTestCase
 {
@@ -32,7 +33,7 @@ class SftpConnectorTest extends AbstractTestCase
             'password' => 'your-password',
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\Sftp\SftpAdapter', $return);
+        $this->assertInstanceOf(SftpAdapter::class, $return);
     }
 
     protected function getSftpConnector()

--- a/tests/Adapters/WebDavConnectorTest.php
+++ b/tests/Adapters/WebDavConnectorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,11 +13,12 @@ namespace GrahamCampbell\Tests\Flysystem\Adapters;
 
 use GrahamCampbell\Flysystem\Adapters\WebDavConnector;
 use GrahamCampbell\TestBench\AbstractTestCase;
+use League\Flysystem\WebDAV\WebDAVAdapter;
 
 /**
  * This is the webdav connector test class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class WebDavConnectorTest extends AbstractTestCase
 {
@@ -31,7 +32,7 @@ class WebDavConnectorTest extends AbstractTestCase
             'password' => 'your-password',
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\WebDAV\WebDAVAdapter', $return);
+        $this->assertInstanceOf(WebDAVAdapter::class, $return);
     }
 
     protected function getWebDavConnector()

--- a/tests/Adapters/ZipConnectorTest.php
+++ b/tests/Adapters/ZipConnectorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of Laravel Flysystem.
  *
- * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Graham Campbell <graham@cachethq.io>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,11 +13,12 @@ namespace GrahamCampbell\Tests\Flysystem\Adapters;
 
 use GrahamCampbell\Flysystem\Adapters\ZipConnector;
 use GrahamCampbell\TestBench\AbstractTestCase;
+use League\Flysystem\ZipArchive\ZipArchiveAdapter;
 
 /**
  * This is the zip connector test class.
  *
- * @author Graham Campbell <graham@mineuk.com>
+ * @author Graham Campbell <graham@cachethq.io>
  */
 class ZipConnectorTest extends AbstractTestCase
 {
@@ -27,7 +28,7 @@ class ZipConnectorTest extends AbstractTestCase
 
         $return = $connector->connect(['path' => __DIR__.'\stubs\test.zip']);
 
-        $this->assertInstanceOf('League\Flysystem\ZipArchive\ZipArchiveAdapter', $return);
+        $this->assertInstanceOf(ZipArchiveAdapter::class, $return);
     }
 
     public function testConnectWithPrefix()
@@ -36,7 +37,7 @@ class ZipConnectorTest extends AbstractTestCase
 
         $return = $connector->connect(['path' => __DIR__.'\stubs\test.zip', 'prefix' => 'your-prefix']);
 
-        $this->assertInstanceOf('League\Flysystem\ZipArchive\ZipArchiveAdapter', $return);
+        $this->assertInstanceOf(ZipArchiveAdapter::class, $return);
     }
 
     /**


### PR DESCRIPTION
Updated the AWS S3 adapter to use v3 up from v2.  Updated adapters to be latest from L5 branch.

Unfortunately for Laravel 4 there's no branch, only the 1.0.0 tag.  If a branch could be created for that, I'd gladly push to there.

This appears to pass the unit tests when on the right tag.