### PR TITLE
Allow for greater configuration of local connections

### DIFF
--- a/src/Adapters/LocalConnector.php
+++ b/src/Adapters/LocalConnector.php
@@ -51,7 +51,7 @@ class LocalConnector implements ConnectorInterface
             throw new InvalidArgumentException('The local connector requires path configuration.');
         }
 
-        return array_only($config, ['path']);
+        return array_only($config, ['path', 'write_flags', 'link_handling', 'permissions']);
     }
 
     /**
@@ -63,6 +63,12 @@ class LocalConnector implements ConnectorInterface
      */
     protected function getAdapter(array $config)
     {
-        return new Local($config['path']);
+        // Pull parameters from config and set defaults for optional values
+        $path = $config['path'];
+        $writeFlags = array_get($config, 'write_flags', LOCK_EX);
+        $linkHandling = array_get($config, 'link_handling', Local::DISALLOW_LINKS);
+        $permissions = array_get($config, 'permissions', []);
+
+        return new Local($path, $writeFlags, $linkHandling, $permissions);
     }
 }

--- a/tests/Functional/LocalFlysystemTest.php
+++ b/tests/Functional/LocalFlysystemTest.php
@@ -13,6 +13,8 @@ namespace GrahamCampbell\Tests\Flysystem\Functional;
 
 use GrahamCampbell\Flysystem\Facades\Flysystem;
 use GrahamCampbell\Tests\Flysystem\AbstractTestCase;
+use League\Flysystem\Adapter\Local as LocalAdapter;
+use League\Flysystem\AdapterInterface;
 
 /**
  * This is the local flysystem test class.
@@ -54,5 +56,107 @@ class LocalFlysystemTest extends AbstractTestCase
         } finally {
             $this->app->files->deleteDirectory(realpath(__DIR__.'/../../').'/temp');
         }
+    }
+
+    /**
+     * Asserts that custom permissions set on the connection config are honored
+     * when creating files and directories.
+     *
+     * @return null
+     */
+    public function testCustomPermissions()
+    {
+        try {
+            $this->app->files->deleteDirectory(realpath(__DIR__.'/../../').'/temp');
+
+            $old = $this->app->config->get('flysystem.connections');
+
+            $new = array_merge($old, [
+                'testing' => [
+                    'driver'      => 'local',
+                    'path'        => realpath(__DIR__.'/../../').'/temp',
+                    'permissions' => [
+                        'file' => [
+                            'public'  => 0666,
+                            'private' => 0600,
+                        ],
+                        'dir' => [
+                            'public'  => 0777,
+                            'private' => 0700,
+                        ],
+                    ],
+                ],
+            ]);
+
+            $this->app->config->set('flysystem.connections', $new);
+            $this->app->config->set('flysystem.default', 'testing');
+
+            Flysystem::put('public-file', 'bar', ['visibility' => AdapterInterface::VISIBILITY_PUBLIC]);
+            Flysystem::put('private-file', 'bar', ['visibility' => AdapterInterface::VISIBILITY_PRIVATE]);
+
+            Flysystem::createDir('public-dir', ['visibility' => AdapterInterface::VISIBILITY_PUBLIC]);
+            Flysystem::createDir('private-dir', ['visibility' => AdapterInterface::VISIBILITY_PRIVATE]);
+
+            $this->assertSame('666', self::getMask(Flysystem::getAdapter()->applyPathPrefix('public-file')));
+            $this->assertSame('600', self::getMask(Flysystem::getAdapter()->applyPathPrefix('private-file')));
+            $this->assertSame('777', self::getMask(Flysystem::getAdapter()->applyPathPrefix('public-dir')));
+            $this->assertSame('700', self::getMask(Flysystem::getAdapter()->applyPathPrefix('private-dir')));
+        } finally {
+            $this->app->files->deleteDirectory(realpath(__DIR__.'/../../').'/temp');
+        }
+    }
+
+    /**
+     * Asserts that custom link handling is properly set on the connection.
+     *
+     * @return null
+     */
+    public function testCustomSymlinkSettings()
+    {
+        $linkHandlingFailed = false;
+
+        try {
+            $this->app->files->deleteDirectory(realpath(__DIR__.'/../../').'/temp');
+
+            $old = $this->app->config->get('flysystem.connections');
+
+            $new = array_merge($old, [
+                'testing' => [
+                    'driver'        => 'local',
+                    'path'          => realpath(__DIR__.'/../../').'/temp',
+                    'link_handling' => LocalAdapter::SKIP_LINKS,
+                ],
+            ]);
+
+            $this->app->config->set('flysystem.connections', $new);
+            $this->app->config->set('flysystem.default', 'testing');
+
+            Flysystem::put('foo', 'foo');
+            symlink(Flysystem::getAdapter()->applyPathPrefix('foo'), Flysystem::getAdapter()->applyPathPrefix('bar'));
+
+            // Will throw an exception if custom link handling isn't set correctly
+            Flysystem::get('bar');
+        } catch (\League\Flysystem\NotSupportedException $e) {
+            // If the link handling failed then catch it and set a flag to be
+            // consumed by the assertion below
+            $linkHandlingFailed = true;
+        } finally {
+            $this->assertFalse($linkHandlingFailed);
+            $this->app->files->deleteDirectory(realpath(__DIR__.'/../../').'/temp');
+        }
+    }
+
+    /**
+     * Get the permissions mask of the file/directory specified.
+     *
+     * @param string $file file or directory name
+     *
+     * @return int
+     */
+    private static function getMask($file)
+    {
+        clearstatcache();
+
+        return decoct(fileperms($file) & 0777);
     }
 }


### PR DESCRIPTION
In my case in particular I wanted to be able to specify the default file/directory umask. Couldn't see an easy way of doing that so I'm made this patch. Change is backward compatible. Simply allows callers to pass config options via .env / conf file, defaults are used if not explicitly set in config.