### PR TITLE
allow users to pass in credentials to the AwsS3Connector in the config

### DIFF
--- a/src/Adapters/AwsS3Connector.php
+++ b/src/Adapters/AwsS3Connector.php
@@ -66,8 +66,13 @@ class AwsS3Connector implements ConnectorInterface
         $auth = [
             'region'      => $config['region'],
             'version'     => $config['version'],
-            'credentials' => array_only($config, ['key', 'secret']),
         ];
+
+        if (array_key_exists('credentials', $config)) {
+            $auth['credentials'] = $config['credentials'];
+        } else {
+            $auth['credentials'] = array_only($config, ['key', 'secret']);
+        }
 
         if (array_key_exists('bucket_endpoint', $config)) {
             $auth['bucket_endpoint'] = $config['bucket_endpoint'];

--- a/tests/Adapters/AwsS3ConnectorTest.php
+++ b/tests/Adapters/AwsS3ConnectorTest.php
@@ -137,6 +137,25 @@ class AwsS3ConnectorTest extends AbstractTestCase
         $this->assertInstanceOf(AwsS3Adapter::class, $return);
     }
 
+    public function testConnectWithCredentials()
+    {
+        $connector = $this->getAwsS3Connector();
+
+        $return = $connector->connect([
+            'key'         => null,
+            'secret'      => null,
+            'credentials' => [
+                'key'    => 'your-credentials-key',
+                'secret' => 'your-credentials-secret',
+            ],
+            'bucket'      => 'your-bucket',
+            'region'      => 'us-east-1',
+            'version'     => 'latest',
+        ]);
+
+        $this->assertInstanceOf(AwsS3Adapter::class, $return);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The awss3 connector requires bucket configuration.

--- a/tests/Adapters/AwsS3ConnectorTest.php
+++ b/tests/Adapters/AwsS3ConnectorTest.php
@@ -137,17 +137,25 @@ class AwsS3ConnectorTest extends AbstractTestCase
         $this->assertInstanceOf(AwsS3Adapter::class, $return);
     }
 
+    /**
+     * Testing credential providers
+     *
+     * Using the provider to grab credentials from environment variables
+     */
     public function testConnectWithCredentials()
     {
         $connector = $this->getAwsS3Connector();
 
+        putenv('AWS_ACCESS_KEY_ID=your-access-key');
+        putenv('AWS_SECRET_ACCESS_KEY=your-secret');
+
+        $provider = \Aws\Credentials\CredentialProvider::defaultProvider();
+        $credentials = $provider()->wait();
+
         $return = $connector->connect([
             'key'         => null,
             'secret'      => null,
-            'credentials' => [
-                'key'    => 'your-credentials-key',
-                'secret' => 'your-credentials-secret',
-            ],
+            'credentials' => $credentials,
             'bucket'      => 'your-bucket',
             'region'      => 'us-east-1',
             'version'     => 'latest',

--- a/tests/Adapters/AwsS3ConnectorTest.php
+++ b/tests/Adapters/AwsS3ConnectorTest.php
@@ -138,7 +138,7 @@ class AwsS3ConnectorTest extends AbstractTestCase
     }
 
     /**
-     * Testing credential providers
+     * Testing credential providers.
      *
      * Using the provider to grab credentials from environment variables
      */


### PR DESCRIPTION
creates ability to utilize credential providers for the S3 adapter.

http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/credentials.html