### PR TITLE
Added support for Backblaze B2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ There are also some additional dependencies you will need to install for some of
 
 * The AwsS3 adapter requires `league/flysystem-aws-s3-v3` (`^1.0`).
 * The Azure adapter requires `league/flysystem-azure` (`^1.0`).
+* The Backblaze B2 adapter requires `mhetreramesh/flysystem-backblaze` (`^1.0`)
 * The Dropbox adapter requires `spatie/flysystem-dropbox` (`^1.0`).
 * The GridFS adapter requires `league/flysystem-gridfs` (`^1.0`).
 * The Rackspace adapter requires `league/flysystem-rackspace` (`^1.0`).

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "graham-campbell/testbench": "^4.0",
         "league/flysystem-aws-s3-v3": "^1.0",
         "league/flysystem-azure": "^1.0",
+        "mhetreramesh/flysystem-backblaze": "^1.0",
         "league/flysystem-cached-adapter": "^1.0",
         "spatie/flysystem-dropbox": "^1.0",
         "league/flysystem-eventable-filesystem": "^1.0",

--- a/config/flysystem.php
+++ b/config/flysystem.php
@@ -67,6 +67,13 @@ return [
             // 'eventable'    => true,
             // 'cache'        => 'foo'
         ],
+        
+        'backblaze' => [
+            'driver'         => 'backblaze',
+            'accountId'      => 'your-account-id',
+            'applicationKey' => 'your-application-key',
+            'bucket'         => 'your-bucket'
+        ],
 
         'dropbox' => [
             'driver'     => 'dropbox',

--- a/config/flysystem.php
+++ b/config/flysystem.php
@@ -67,12 +67,12 @@ return [
             // 'eventable'    => true,
             // 'cache'        => 'foo'
         ],
-        
+
         'backblaze' => [
             'driver'         => 'backblaze',
             'accountId'      => 'your-account-id',
             'applicationKey' => 'your-application-key',
-            'bucket'         => 'your-bucket'
+            'bucket'         => 'your-bucket',
         ],
 
         'dropbox' => [

--- a/src/Adapters/BackblazeConnector.php
+++ b/src/Adapters/BackblazeConnector.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Laravel Flysystem.
+ *
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace GrahamCampbell\Flysystem\Adapters;
+
+use ChrisWhite\B2\Client;
+use GrahamCampbell\Manager\ConnectorInterface;
+use InvalidArgumentException;
+use Mhetreramesh\Flysystem\BackblazeAdapter;
+
+/**
+ * This is the backblaze connector class.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ * @author Mattia Trapani <mattia.trapani@gmail.com>
+ */
+class BackblazeConnector implements ConnectorInterface
+{
+    /**
+     * Establish an adapter connection.
+     *
+     * @param string[] $config
+     *
+     * @return \Mhetreramesh\Flysystem\BackblazeAdapter
+     */
+    public function connect(array $config)
+    {
+        $auth = $this->getAuth($config);
+        $client = $this->getClient($auth);
+        $config = $this->getConfig($config);
+
+        return $this->getAdapter($client, $config);
+    }
+
+    /**
+     * Get the authentication data.
+     *
+     * @param string[] $config
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return string[]
+     */
+    protected function getAuth(array $config)
+    {
+        if (!array_key_exists('accountId', $config)) {
+            throw new InvalidArgumentException('The backblaze connector requires accountId.');
+        }
+
+        if (!array_key_exists('applicationKey', $config)) {
+            throw new InvalidArgumentException('The backblaze connector requires applicationKey.');
+        }
+
+        $auth = array_only($config, ['accountId', 'applicationKey']);
+
+        return $auth;
+    }
+
+    /**
+     * Get the backblaze client.
+     *
+     * @param string[] $auth
+     *
+     * @return \ChrisWhite\B2\Client
+     */
+    protected function getClient(array $auth)
+    {
+        return new Client($auth['accountId'], $auth['applicationKey']);
+    }
+
+    /**
+     * Get the configuration.
+     *
+     * @param string[] $config
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return array
+     */
+    protected function getConfig(array $config)
+    {
+        if (!array_key_exists('bucket', $config)) {
+            throw new InvalidArgumentException('The backblaze connector requires bucket configuration.');
+        }
+
+        return array_only($config, ['bucket']);
+    }
+
+    /**
+     * Get the backblaze adapter.
+     *
+     * @param \ChrisWhite\B2\Client $client
+     * @param string[]              $config
+     *
+     * @return \Mhetreramesh\Flysystem\BackblazeAdapter
+     */
+    protected function getAdapter(Client $client, array $config)
+    {
+        return new BackblazeAdapter($client, $config['bucket']);
+    }
+}

--- a/src/Adapters/ConnectionFactory.php
+++ b/src/Adapters/ConnectionFactory.php
@@ -54,6 +54,8 @@ class ConnectionFactory
                 return new AwsS3Connector();
             case 'azure':
                 return new AzureConnector();
+            case 'backblaze':
+                return new BackblazeConnector();
             case 'dropbox':
                 return new DropboxConnector();
             case 'ftp':

--- a/tests/Adapters/BackblazeConnectorTest.php
+++ b/tests/Adapters/BackblazeConnectorTest.php
@@ -56,7 +56,7 @@ class BackblazeConnectorTest extends AbstractTestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The backblaze connector requires accountId.
      */
-    public function testConnectWithoutApplicationKey()
+    public function testConnectWithoutAccountId()
     {
         $connector = $this->getBackblazeConnector();
 

--- a/tests/Adapters/BackblazeConnectorTest.php
+++ b/tests/Adapters/BackblazeConnectorTest.php
@@ -32,7 +32,7 @@ class BackblazeConnectorTest extends AbstractTestCase
         $return = $connector->connect([
             'accountId'      => 'your-account-id',
             'applicationKey' => 'your-application-key',
-            'bucket'         => 'your-bucket'
+            'bucket'         => 'your-bucket',
         ]);
 
         $this->assertInstanceOf(BackblazeAdapter::class, $return);
@@ -48,7 +48,7 @@ class BackblazeConnectorTest extends AbstractTestCase
 
         $connector->connect([
             'accountId'      => 'your-account-id',
-            'applicationKey' => 'your-application-key'
+            'applicationKey' => 'your-application-key',
         ]);
     }
 
@@ -62,7 +62,7 @@ class BackblazeConnectorTest extends AbstractTestCase
 
         $connector->connect([
             'applicationKey' => 'your-application-key',
-            'bucket'         => 'your-bucket'
+            'bucket'         => 'your-bucket',
         ]);
     }
 
@@ -76,7 +76,7 @@ class BackblazeConnectorTest extends AbstractTestCase
 
         $connector->connect([
             'accountId' => 'your-account-id',
-            'bucket'    => 'your-bucket'
+            'bucket'    => 'your-bucket',
         ]);
     }
 

--- a/tests/Adapters/BackblazeConnectorTest.php
+++ b/tests/Adapters/BackblazeConnectorTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Laravel Flysystem.
+ *
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace GrahamCampbell\Tests\Flysystem\Adapters;
+
+use GrahamCampbell\Flysystem\Adapters\BackblazeConnector;
+use GrahamCampbell\TestBench\AbstractTestCase;
+use Mhetreramesh\Flysystem\BackblazeAdapter;
+
+/**
+ * This is the backblaze connector test class.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ * @author Mattia Trapani <mattia.trapani@gmail.com>
+ */
+class BackblazeConnectorTest extends AbstractTestCase
+{
+    public function testConnectStandard()
+    {
+        $connector = $this->getBackblazeConnector();
+
+        $return = $connector->connect([
+            'accountId'      => 'your-account-id',
+            'applicationKey' => 'your-application-key',
+            'bucket'         => 'your-bucket'
+        ]);
+
+        $this->assertInstanceOf(BackblazeAdapter::class, $return);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The backblaze connector requires bucket configuration.
+     */
+    public function testConnectWithoutBucket()
+    {
+        $connector = $this->getBackblazeConnector();
+
+        $connector->connect([
+            'accountId'      => 'your-account-id',
+            'applicationKey' => 'your-application-key'
+        ]);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The backblaze connector requires accountId.
+     */
+    public function testConnectWithoutApplicationKey()
+    {
+        $connector = $this->getBackblazeConnector();
+
+        $connector->connect([
+            'applicationKey' => 'your-application-key',
+            'bucket'         => 'your-bucket'
+        ]);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The backblaze connector requires applicationKey.
+     */
+    public function testConnectWithoutApplicationKey()
+    {
+        $connector = $this->getBackblazeConnector();
+
+        $connector->connect([
+            'accountId' => 'your-account-id',
+            'bucket'    => 'your-bucket'
+        ]);
+    }
+
+    protected function getBackblazeConnector()
+    {
+        return new BackblazeConnector();
+    }
+}

--- a/tests/Adapters/ConnectionFactoryTest.php
+++ b/tests/Adapters/ConnectionFactoryTest.php
@@ -15,6 +15,7 @@ namespace GrahamCampbell\Tests\Flysystem\Adapters;
 
 use GrahamCampbell\Flysystem\Adapters\AwsS3Connector;
 use GrahamCampbell\Flysystem\Adapters\AzureConnector;
+use GrahamCampbell\Flysystem\Adapters\BackblazeConnector;
 use GrahamCampbell\Flysystem\Adapters\ConnectionFactory;
 use GrahamCampbell\Flysystem\Adapters\DropboxConnector;
 use GrahamCampbell\Flysystem\Adapters\FtpConnector;
@@ -51,6 +52,7 @@ class ConnectionFactoryTest extends AbstractTestCase
         return [
             ['awss3', AwsS3Connector::class],
             ['azure', AzureConnector::class],
+            ['backblaze', BackblazeConnector::class],
             ['dropbox', DropboxConnector::class],
             ['ftp', FtpConnector::class],
             ['gridfs', GridFSConnector::class],


### PR DESCRIPTION
Hi Graham,
I've added support for Backblaze B2 through mhetreramesh/flysystem-backblaze.

I've only one issue in tests: the Backblaze Adapter requires a valid accountId and applicationKey so the test fails. How can this be solved?

Thank you